### PR TITLE
Analytic events ws connector

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -57,6 +57,24 @@
             },
             "console": "integratedTerminal",
             "sourceMaps": true
+        },
+        {
+            "name": "Jest workplace-connector",
+            "type": "node",
+            "request": "launch",
+            "program": "${workspaceRoot}/node_modules/jest/bin/jest.js",
+            "stopOnEntry": false,
+            "args": [
+                 "--runInBand", "--forceExit", "--detectOpenHandles", "--watch"
+            ],
+            "cwd": "${workspaceRoot}/packages/search-ui-workplace-search-connector",
+            "preLaunchTask": null,
+            "runtimeExecutable": null,
+            "env": {
+                "NODE_ENV": "test"
+            },
+            "console": "integratedTerminal",
+            "sourceMaps": true
         }
     ]
 }

--- a/packages/search-ui-workplace-search-connector/src/WorkplaceSearchAPIConnector.ts
+++ b/packages/search-ui-workplace-search-connector/src/WorkplaceSearchAPIConnector.ts
@@ -8,7 +8,9 @@ import type {
   RequestState,
   SearchState,
   AutocompleteQuery,
-  SuggestionsQueryConfig
+  SuggestionsQueryConfig,
+  SearchResult,
+  AutocompletedResult
 } from "@elastic/search-ui";
 import { INVALID_CREDENTIALS } from "@elastic/search-ui";
 
@@ -25,6 +27,14 @@ export type WorkplaceSearchAPIConnectorParams = {
 interface ResultClickParams {
   documentId: string;
   requestId: string;
+  result: SearchResult;
+  page: number;
+}
+
+interface AutocompleteClickParams {
+  documentId: string;
+  requestId: string;
+  result: AutocompletedResult;
 }
 
 export type SearchQueryHook = (
@@ -175,21 +185,11 @@ class WorkplaceSearchAPIConnector {
     }
   }
 
-  onResultClick({ documentId, requestId }: ResultClickParams): void {
-    const apiUrl = `${this.enterpriseSearchBase}/api/ws/v1/analytics/event`;
-
-    this.performFetchRequest(apiUrl, {
-      type: "click",
-      document_id: documentId,
-      query_id: requestId,
-      content_source_id: null, // todo: where would this be available?
-      page: 1 // todo: where can i reach to meta?
-    });
-  }
-
-  onAutocompleteResultClick({
+  onResultClick({
     documentId,
-    requestId
+    requestId,
+    result,
+    page
   }: ResultClickParams): void {
     const apiUrl = `${this.enterpriseSearchBase}/api/ws/v1/analytics/event`;
 
@@ -197,7 +197,23 @@ class WorkplaceSearchAPIConnector {
       type: "click",
       document_id: documentId,
       query_id: requestId,
-      content_source_id: null, // where would this be available?
+      content_source_id: result?._meta.content_source_id,
+      page: page
+    });
+  }
+
+  onAutocompleteResultClick({
+    documentId,
+    requestId,
+    result
+  }: AutocompleteClickParams): void {
+    const apiUrl = `${this.enterpriseSearchBase}/api/ws/v1/analytics/event`;
+
+    this.performFetchRequest(apiUrl, {
+      type: "click",
+      document_id: documentId,
+      query_id: requestId,
+      content_source_id: result?._meta.content_source_id,
       page: 1
     });
   }

--- a/packages/search-ui-workplace-search-connector/src/WorkplaceSearchAPIConnector.ts
+++ b/packages/search-ui-workplace-search-connector/src/WorkplaceSearchAPIConnector.ts
@@ -23,10 +23,8 @@ export type WorkplaceSearchAPIConnectorParams = {
 };
 
 interface ResultClickParams {
-  query: string;
   documentId: string;
   requestId: string;
-  tags: string[];
 }
 
 export type SearchQueryHook = (
@@ -177,24 +175,50 @@ class WorkplaceSearchAPIConnector {
     }
   }
 
-  onResultClick({
-    query,
-    documentId,
-    requestId,
-    tags = []
-  }: ResultClickParams): void {
-    tags = tags.concat("results");
-    return this.client.click({ query, documentId, requestId, tags });
+  onResultClick({ documentId, requestId }: ResultClickParams): void {
+    const apiUrl = `${this.enterpriseSearchBase}/api/ws/v1/analytics/event`;
+
+    this.performFetchRequest(apiUrl, {
+      type: "click",
+      document_id: documentId,
+      query_id: requestId,
+      content_source_id: null, // todo: where would this be available?
+      page: 1 // todo: where can i reach to meta?
+    });
   }
 
   onAutocompleteResultClick({
-    query,
     documentId,
-    requestId,
-    tags = []
+    requestId
   }: ResultClickParams): void {
-    tags = tags.concat("autocomplete");
-    return this.client.click({ query, documentId, requestId, tags });
+    const apiUrl = `${this.enterpriseSearchBase}/api/ws/v1/analytics/event`;
+
+    this.performFetchRequest(apiUrl, {
+      type: "click",
+      document_id: documentId,
+      query_id: requestId,
+      content_source_id: null, // where would this be available?
+      page: 1
+    });
+  }
+
+  async performFetchRequest(apiUrl: string, payload: any) {
+    const searchResponse = await fetch(apiUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${this.accessToken}`
+      },
+      body: JSON.stringify(payload)
+    });
+
+    if (searchResponse.status === 401) {
+      this.state.isLoggedIn = false; // Remove the token to trigger the Log in dialog
+      throw new Error(INVALID_CREDENTIALS);
+    }
+
+    const responseJson = await searchResponse.json();
+    return responseJson;
   }
 
   async onSearch(
@@ -236,33 +260,17 @@ class WorkplaceSearchAPIConnector {
 
     return this.beforeSearchCall(options, async (newOptions) => {
       // TODO: temporary code until we have the enterprise-search-js client
-      const searchResponse = await fetch(
-        `${this.enterpriseSearchBase}/api/ws/v1/search`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${this.accessToken}`
-          },
-          body: JSON.stringify({
-            query,
-            ...newOptions
-          })
-        }
-      );
+      const apiUrl = `${this.enterpriseSearchBase}/api/ws/v1/search`;
 
-      if (searchResponse.status === 401) {
-        this.state.isLoggedIn = false; // Remove the token to trigger the Log in dialog
-        throw new Error(INVALID_CREDENTIALS);
-      }
-
-      const responseJson = await searchResponse.json();
-
-      // const response = await this.client.search(query, newOptions);
+      const responseJson = await this.performFetchRequest(apiUrl, {
+        query,
+        ...newOptions
+      });
       return adaptResponse(
         responseJson,
         buildResponseAdapterOptions(queryConfig)
       );
+      // const response = await this.client.search(query, newOptions);
     });
   }
 
@@ -307,25 +315,16 @@ class WorkplaceSearchAPIConnector {
       const options = removeInvalidFields(withQueryConfigOptions);
 
       this.beforeAutocompleteResultsCall(options, async (newOptions) => {
-        const searchResponse = await fetch(
+        const responseJson = await this.performFetchRequest(
           `${this.enterpriseSearchBase}/api/ws/v1/search`,
           {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              Authorization: `Bearer ${this.accessToken}`
-            },
-            body: JSON.stringify({
-              query,
-              ...newOptions
-            })
+            query,
+            ...newOptions
           }
         );
 
-        const responseJson = await searchResponse.json();
-
         autocompletedState.autocompletedResults =
-          adaptResponse(responseJson).results;
+          adaptResponse(responseJson)?.results || [];
         autocompletedState.autocompletedResultsRequestId =
           responseJson.meta.request_id;
       });

--- a/packages/search-ui-workplace-search-connector/src/WorkplaceSearchAPIConnector.ts
+++ b/packages/search-ui-workplace-search-connector/src/WorkplaceSearchAPIConnector.ts
@@ -198,7 +198,10 @@ class WorkplaceSearchAPIConnector {
       document_id: documentId,
       query_id: requestId,
       content_source_id: result?._meta.content_source_id,
-      page: page
+      page: page,
+      rank: 1,
+      event: "api",
+      score: result?._meta.score
     });
   }
 

--- a/packages/search-ui-workplace-search-connector/src/__tests__/WorkplaceSearchAPIConnector.test.ts
+++ b/packages/search-ui-workplace-search-connector/src/__tests__/WorkplaceSearchAPIConnector.test.ts
@@ -72,7 +72,9 @@ describe("WorkplaceSearchAPIConnector", () => {
 
       return connector.onResultClick({
         documentId: "11111",
-        requestId: "12345"
+        requestId: "12345",
+        page: 1,
+        result: exampleResponse.results[0]
       });
     }
 
@@ -81,7 +83,7 @@ describe("WorkplaceSearchAPIConnector", () => {
       const { body } = getLastFetchCall();
       expect(body).toMatchInlineSnapshot(`
         Object {
-          "content_source_id": null,
+          "content_source_id": "621581b6174a804659f9dc16",
           "document_id": "11111",
           "page": 1,
           "query_id": "12345",
@@ -186,7 +188,8 @@ describe("WorkplaceSearchAPIConnector", () => {
 
         return connector.onAutocompleteResultClick({
           documentId: "11111",
-          requestId: "12345"
+          requestId: "12345",
+          result: exampleResponse.results[0]
         });
       }
 
@@ -195,7 +198,7 @@ describe("WorkplaceSearchAPIConnector", () => {
         const { body } = getLastFetchCall();
         expect(body).toMatchInlineSnapshot(`
           Object {
-            "content_source_id": null,
+            "content_source_id": "621581b6174a804659f9dc16",
             "document_id": "11111",
             "page": 1,
             "query_id": "12345",

--- a/packages/search-ui/src/__tests__/actions/trackAutocompleteClickThrough.test.ts
+++ b/packages/search-ui/src/__tests__/actions/trackAutocompleteClickThrough.test.ts
@@ -12,6 +12,20 @@ describe("#trackAutocompleteClickThrough", () => {
     driver.setSearchTerm("search terms", {
       autocompleteResults: true
     });
+    driver.state.results = [
+      {
+        _meta: {
+          last_updated: "2022-02-23T00:40:10+00:00",
+          source: "custom",
+          content_source_id: "621581b6174a804659f9dc16",
+          id: "park_great-smoky-mountains",
+          score: 2.057784
+        },
+        last_updated: {
+          raw: "2022-02-23T00:40:10+00:00"
+        }
+      }
+    ];
     driver.trackAutocompleteClickThrough(documentId, tags);
     return { driver, mockApiConnector, updatedStateAfterAction };
   }
@@ -22,12 +36,15 @@ describe("#trackAutocompleteClickThrough", () => {
   });
 
   it("Calls Connector 'autocompleteClick' with correct parameters", () => {
-    const { mockApiConnector } = subject({}, 1, ["test"]);
-    const [{ query, documentId, requestId, tags }] =
+    const { mockApiConnector } = subject({}, "park_great-smoky-mountains", [
+      "test"
+    ]);
+    const [{ query, documentId, requestId, tags, result }] =
       getAutocompleteClickCalls(mockApiConnector)[0];
-    expect(documentId).toEqual(1);
+    expect(documentId).toEqual("park_great-smoky-mountains");
     expect(query).toEqual("search terms");
     expect(tags).toEqual(["test"]);
     expect(requestId).toEqual("6789");
+    expect(result._meta.content_source_id).toEqual("621581b6174a804659f9dc16");
   });
 });

--- a/packages/search-ui/src/__tests__/actions/trackClickThrough.test.ts
+++ b/packages/search-ui/src/__tests__/actions/trackClickThrough.test.ts
@@ -7,6 +7,21 @@ describe("#trackClickThrough", () => {
     tags?: string[]
   ) {
     const { driver, mockApiConnector } = setupDriver({ initialState });
+    driver.state.results = [
+      {
+        _meta: {
+          last_updated: "2022-02-23T00:40:10+00:00",
+          source: "custom",
+          content_source_id: "621581b6174a804659f9dc16",
+          id: "park_great-smoky-mountains",
+          score: 2.057784
+        },
+        last_updated: {
+          raw: "2022-02-23T00:40:10+00:00"
+        }
+      }
+    ];
+    driver.state.current = 1;
     driver.trackClickThrough(documentId, tags);
     jest.runAllTimers();
     return { driver, mockApiConnector };
@@ -20,14 +35,16 @@ describe("#trackClickThrough", () => {
   it("Calls Connector 'click' with correct parameters", () => {
     const { mockApiConnector } = subject(
       { initialState: { searchTerm: "search terms" } },
-      "1",
+      "park_great-smoky-mountains",
       ["test"]
     );
-    const [{ query, documentId, requestId, tags }] =
+    const [{ query, documentId, requestId, tags, result, page }] =
       getClickCalls(mockApiConnector)[0];
-    expect(documentId).toEqual("1");
+    expect(documentId).toEqual("park_great-smoky-mountains");
     expect(query).toEqual("search terms");
     expect(tags).toEqual(["test"]);
     expect(requestId).toEqual("12345");
+    expect(result._meta.content_source_id).toEqual("621581b6174a804659f9dc16");
+    expect(page).toBe(1);
   });
 });

--- a/packages/search-ui/src/actions/trackAutocompleteClickThrough.ts
+++ b/packages/search-ui/src/actions/trackAutocompleteClickThrough.ts
@@ -20,12 +20,14 @@ export default function trackAutocompleteClickThrough(
     );
   }
 
-  const { autocompletedResultsRequestId, searchTerm } = this.state;
+  const { autocompletedResultsRequestId, searchTerm, results } = this.state;
+  const result = results.find((result) => result._meta.id === documentId);
 
   this.events.autocompleteResultClick({
     query: searchTerm,
     documentId,
     requestId: autocompletedResultsRequestId,
-    tags
+    tags,
+    result
   });
 }

--- a/packages/search-ui/src/actions/trackClickThrough.ts
+++ b/packages/search-ui/src/actions/trackClickThrough.ts
@@ -1,3 +1,5 @@
+import { SearchState } from "..";
+
 /**
  * Report a click through event. A click through event is when a user
  * clicks on a result link.
@@ -15,12 +17,16 @@ export default function trackClickThrough(
     // eslint-disable-next-line no-console
     console.log("Search UI: Action", "trackClickThrough", ...arguments);
 
-  const { requestId, searchTerm } = this.state;
+  const { requestId, searchTerm, results, current }: SearchState = this.state;
+
+  const result = results.find((result) => result._meta.id === documentId);
 
   this.events.resultClick({
     query: searchTerm,
     documentId,
     requestId,
-    tags
+    tags,
+    result,
+    page: current
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14628,17 +14628,7 @@ react-docgen@^3.0.0:
     node-dir "^0.1.10"
     recast "^0.16.0"
 
-react-dom@^16.7.0:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
-  integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.19.1"
-
-react-dom@^17.0.2:
+react-dom@17.0.2, react-dom@^16.7.0, react-dom@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
   integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
@@ -14949,16 +14939,7 @@ react-window@^1.8.6:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"
 
-react@^16.7.0:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
-  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-
-react@^17.0.2:
+react@17.0.2, react@^16.7.0, react@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
   integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
@@ -15712,14 +15693,6 @@ saxes@^5.0.1:
   integrity sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==
   dependencies:
     xmlchars "^2.2.0"
-
-scheduler@^0.19.1:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
-  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 scheduler@^0.20.2:
   version "0.20.2"


### PR DESCRIPTION
PR implements the `onResultClick` and `onAutocompleteResultClick` methods for the WS connector package. 

Analytics API documentation used was https://www.elastic.co/guide/en/workplace-search/current/workplace-search-analytics-event-api.html.

Outstanding:
- content_source_id and if / how thats provided to `onResultClick` and `onAutocompleteResultClick` methods
- validating this works on real API (unit tested only)